### PR TITLE
Fix broking link to net-next

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -417,7 +417,7 @@ to start with “kernel documentation”, which is dense).
     BPF patches land in this tree. It is regularly merged into
     [net-next](https://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git),
     which is itself merged for each release to Linus' tree.
--   [Kernel documentation](https://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git/tree/Documentation/bpf/bpf_devel_QA.txt)
+-   [Kernel documentation](https://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git/tree/Documentation/bpf/bpf_devel_QA.rst)
     about contributions to BPF.
 -   [The netdev mailing list](http://lists.openwall.net/netdev/) - Mailing list
     for Linux kernel networking stack development. All patches are sent there


### PR DESCRIPTION
The file bpf_devel_QA.txt was renamed to bpf_devel_QA.rst

Signed-off-by: Jesper Dangaard Brouer <brouer@redhat.com>