### PR TITLE
Added MPLSinIP example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -297,6 +297,9 @@ to start with “kernel documentation”, which is dense).
     themselves can be seen as example use cases for BPF programs, mostly for
     tracing and monitoring. bcc tools have been packaged for some Linux
     distributions.
+-   [MPLinIP sample](https://github.com/fzakaria/eBPF-mpls-encap-decap)
+    a heavily commented sample demonstrating how to encapsulate & decapsulate MPLS within IP.
+    the code is commented for those new to kernel development.
 
 ## The Code
 

--- a/readme.md
+++ b/readme.md
@@ -297,9 +297,9 @@ to start with “kernel documentation”, which is dense).
     themselves can be seen as example use cases for BPF programs, mostly for
     tracing and monitoring. bcc tools have been packaged for some Linux
     distributions.
--   [MPLinIP sample](https://github.com/fzakaria/eBPF-mpls-encap-decap)
+-   [MPLSinIP sample](https://github.com/fzakaria/eBPF-mpls-encap-decap)
     a heavily commented sample demonstrating how to encapsulate & decapsulate MPLS within IP.
-    the code is commented for those new to kernel development.
+    The code is commented for those new to BPF development.
 
 ## The Code
 


### PR DESCRIPTION
I have created what I believe to be a good sample of writing an eBPF filter that is heavily commented and opts for readability rather than terseness. 

https://github.com/fzakaria/eBPF-mpls-encap-decap

I would like to include it as an example.