### PR TITLE
Added libbpf-bootstrap project link and tutorial.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -160,9 +160,9 @@ If you are new to eBPF, you may want to try the links described as "introduction
 
 ## Tutorials
 
-- [Building BPF applications with libbpf-bootstrap](https://nakryiko.com/posts/libbpf-bootstrap/) - Get started with your own BPF application quickly and painlessly using the modern BPF CO-RE facilities. No runtime clang/LLVM dependency whatsoever.
 - [bcc Reference Guide](https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md) - Many incremental steps to start using bcc and eBPF, mostly centered on tracing and monitoring.
 - [bcc Python Developer Tutorial](https://github.com/iovisor/bcc/blob/master/docs/tutorial_bcc_python_developer.md) - Comes with bcc, but targets the Python bits across seventeen "lessons".
+- [Building BPF applications with libbpf-bootstrap](https://nakryiko.com/posts/libbpf-bootstrap/) - Helps generate minimal or advanced templates to bootstrap your own applications (kernel side and user space management for maps and programs) with features like CO-RE, global variables, and ring buffer.
 - [Linux Tracing Workshops Materials](https://github.com/goldshtn/linux-tracing-workshop) - Involves the use of several BPF tools for tracing.
 - [Tracing a packet journey using Linux tracepoints, perf and eBPF](https://blog.yadutaf.fr/2017/07/28/tracing-a-packet-journey-using-linux-tracepoints-perf-ebpf/) - Troubleshooting ping requests and replies with perf and bcc programs.
 - [Open NFP platform](https://open-nfp.org/dataplanes-ebpf/technical-papers/) - Operated by Netronome: some tutorials for network-related eBPF use cases, including an eBPF Offload Starting Guide.

--- a/readme.md
+++ b/readme.md
@@ -208,7 +208,7 @@ If you are new to eBPF, you may want to try the links described as "introduction
 ### libbpf
 
 - [libbpf](https://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git/tree/tools/lib/bpf) - A C library used for handling BPF objects (programs and maps), and manipulating ELF object files containing them. It is shipped with the kernel and [mirrored on GitHub](https://github.com/libbpf/libbpf).
-- [libbpf-bootstrap](https://github.com/libbpf/libbpf-bootstrap) - scaffolding for BPF application development with libbpf and BPF CO-RE
+- [libbpf-bootstrap](https://github.com/libbpf/libbpf-bootstrap) - Scaffolding for BPF application development with libbpf and BPF CO-RE.
 
 ### bpftool and Other Tools from the Kernel Tree
 

--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,7 @@ If you are new to eBPF, you may want to try the links described as "introduction
 
 ## Tutorials
 
+- [Building BPF applications with libbpf-bootstrap](https://nakryiko.com/posts/libbpf-bootstrap/) - Get started with your own BPF application quickly and painlessly using the modern BPF CO-RE facilities. No runtime clang/LLVM dependency whatsoever.
 - [bcc Reference Guide](https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md) - Many incremental steps to start using bcc and eBPF, mostly centered on tracing and monitoring.
 - [bcc Python Developer Tutorial](https://github.com/iovisor/bcc/blob/master/docs/tutorial_bcc_python_developer.md) - Comes with bcc, but targets the Python bits across seventeen "lessons".
 - [Linux Tracing Workshops Materials](https://github.com/goldshtn/linux-tracing-workshop) - Involves the use of several BPF tools for tracing.
@@ -207,6 +208,7 @@ If you are new to eBPF, you may want to try the links described as "introduction
 ### libbpf
 
 - [libbpf](https://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git/tree/tools/lib/bpf) - A C library used for handling BPF objects (programs and maps), and manipulating ELF object files containing them. It is shipped with the kernel and [mirrored on GitHub](https://github.com/libbpf/libbpf).
+- [libbpf-bootstrap](https://github.com/libbpf/libbpf-bootstrap) - scaffolding for BPF application development with libbpf and BPF CO-RE
 
 ### bpftool and Other Tools from the Kernel Tree
 


### PR DESCRIPTION
libbpf and CO-RE seem to be a new recommended way of developing BPF programs while BCC's Python bindings are considered deprecated now. Added some links to libbpf related resources.