### PR TITLE
P4 for BCC has been removed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -192,7 +192,6 @@ If you are new to eBPF, you may want to try the links described as "introduction
 ### bcc
 
 - [bcc](https://github.com/iovisor/bcc/) - Framework and set of tools - One way to handle BPF programs, in particular for tracing and monitoring. Also includes some utilities that may help inspect maps or programs on the system.
-- [P4 compiler for BPF targets for bcc](https://github.com/iovisor/bcc/tree/master/src/cc/frontends/p4/compiler) - An alternative to the restricted C.
 - [Lua front-end for BCC](https://github.com/iovisor/bcc/tree/master/src/lua) - Another alternative to C, and even to most of the Python code used in bcc.
 
 ### iproute2


### PR DESCRIPTION
Hence, the proposed link is not valid anymore.
See https://github.com/iovisor/bcc/pull/3759