### PR TITLE
Add OpenCSD work using eBPF for compute kernels

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,7 @@ If you are new to eBPF, you may want to try the links described as "introduction
 
 - [eBPF/XDP hardware offload to SmartNICs](http://netdevconf.org/1.2/session.html?jakub-kicinski) - Hardware offload for eBPF with TC or XDP (Linux kernel 4.9+), introduced by Netronome.
 - [Comprehensive XDP offload---Handling the edge cases](https://www.netdevconf.org/2.2/session.html?viljoen-xdpoffload-talk) - An update on the topic above.
+- [OpenCSD eBPF SSD offloading](https://github.com/Dantali0n/qemu-csd) - Computational Storage simulation (QEMU) platform with FUSE LFS filesystem for Zoned Namespaces NVMe SSDs using uBPF for compute kernel offloading, all in userspace.
 
 ## Tutorials
 


### PR DESCRIPTION
Hello,

I am working on OpenCSD, a complete simulation platform that enables to reason about the use and performance of Computational Storage Devices. The work comes with a FUSE LFS filesystem designed for Zoned Namespaces NVMe SSDs. The filesystem supports multi-user tenancy concurrently for both regular as well as offloaded access (using in-memory snapshots). Offloading compute kernels is achieved through uBPF with a custom ABI for BPF system calls. Compute kernels are registered through the use of filesystem extended attributes. The entire work runs in userspace and does not require kernel modules as a means to simplify ease of use and reduce barrier to entry.