### PR TITLE
Added TripleCross eBPF rootkit to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -323,6 +323,7 @@ If you are new to eBPF, you may want to try the links described as "introduction
 - [ebpfkit](https://github.com/Gui774ume/ebpfkit) - A rootkit that leverages multiple eBPF features to implement offensive security techniques.
 - [ebpfkit-monitor](https://github.com/Gui774ume/ebpfkit-monitor) - An utility to statically analyze eBPF bytecode or monitor suspicious eBPF activity at runtime. It was specifically designed to detect ebpfkit.
 - [Bad BPF](https://github.com/pathtofile/bad-bpf) - A collection of malicious eBPF programs that make use of eBPF's ability to read and write user data in between the usermode program and the kernel.
+- [TripleCross](https://github.com/h3xduck/TripleCross) - A Linux eBPF rootkit with a backdoor, C2, library injection, execution hijacking, persistence and stealth capabilities. 
 
 ## The Code
 


### PR DESCRIPTION
We have created a Linux eBPF rootkit showing the offensive capabilities of the eBPF technology, based on the work of the DEFCON talks. We would like to have it included in the list under the security section if you find it appropiate.