### PR TITLE
Add HookProbe to eBPF in Security

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -345,6 +345,7 @@ If you are new to eBPF, you may want to try the links described as "introduction
 - [bpflock - Lock Linux machines](https://github.com/linux-lock/bpflock) - An eBPF driven security tool for locking and auditing Linux machines.
 - [Tetragon](https://github.com/cilium/tetragon) - Kubernetes-aware, eBPF-based security observability and runtime enforcement.
 - [harpoon](https://github.com/alegrey91/harpoon) - Trace syscalls from user-space functions, by using eBPF.
+- [HookProbe](https://github.com/hookprobe/hookprobe) - Edge IDS using XDP/eBPF for kernel-level packet filtering and DDoS mitigation on ARM devices.
 - [Synapse](https://github.com/gen0sec/synapse) - Extended detection and response (XDR) with eBPF-powered firewall and proxy, to protect your Linux servers.
 - [BPFJailer](https://github.com/gen0sec/bpfjailer) - BpfJailer is an eBPF-based process jailing system that provides mandatory access control (MAC) for Linux.
 - [Bombini](https://github.com/bombinisecurity/bombini) - An eBPF-based security agent written entirely in Rust using the [Aya](https://github.com/aya-rs/aya) library and built on LSM (Linux Security Module) BPF hooks.


### PR DESCRIPTION
## Summary
- Adds [HookProbe](https://github.com/hookprobe/hookprobe) to the **Security** section
- HookProbe is an edge IDS using XDP/eBPF for kernel-level packet filtering and DDoS mitigation on ARM devices
- Entry placed in alphabetical order

## Details
HookProbe uses XDP programs (`xdp_hydra.c`, `xdp_synwall.c`) for fast-path packet filtering, BPF ring buffers for real-time event streaming, and BPF maps for blocklist/allowlist management. It runs on ARM64 edge devices (Raspberry Pi) for distributed network defense.