### PR TITLE
Add gspy to Security category

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -350,7 +350,7 @@ If you are new to eBPF, you may want to try the links described as "introduction
 - [Bombini](https://github.com/bombinisecurity/bombini) - An eBPF-based security agent written entirely in Rust using the [Aya](https://github.com/aya-rs/aya) library and built on LSM (Linux Security Module) BPF hooks.
 - [owLSM](https://github.com/Cybereason-Public/owLSM) - Open source agent that implements a stateful Sigma rules engine focused on monitoring and prevention using eBPF LSM.
 - [Inner Warden](https://github.com/InnerWarden/innerwarden) - A self-defending security agent for Linux and macOS that uses eBPF with 22 kernel hooks (tracepoints, kprobes, LSM, XDP) via the Aya library for real-time threat detection, automated response, and AI-powered triage.
-
+- [gspy](https://github.com/Mutasem-mk4/gspy) - Forensic goroutine-to-syscall inspector for live Go processes.
 ### Linux Scheduler
 
 - [scx](https://github.com/sched-ext/scx) - sched_ext schedulers and tools.


### PR DESCRIPTION
## Description

I'm adding **[gspy](https://github.com/Mutasem-mk4/gspy)** to the \Security\ section.

\gspy\ is a process-scoped forensic goroutine-to-syscall inspector using eBPF uprobes (\untime.execute\) and tracepoints. It maps live Goroutines IDs to syscalls without \ptrace\ or modifying binary footprints.

Thank you for your review.