### PR TITLE
Add netwatch to Observability

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -335,6 +335,7 @@ If you are new to eBPF, you may want to try the links described as "introduction
 - [Coroot](https://github.com/coroot/coroot) - Coroot is an open-source APM and observability tool, a DataDog and NewRelic alternative.
 - [kyanos](https://github.com/hengyoush/kyanos) - Kyanos is an eBPF-based network issue analysis tool that enables you to capture network requests, such as HTTP, Redis, and MySQL requests.
 - [eTraceGen](https://github.com/bhanuprakasheagala/eTraceGen-eBPFEventTelemetryEngine) - eTraceGen is a Linux telemetry engine built with eBPF and Modern C++ that captures kernel-level events for processes, files, system calls, and network with a modular pipeline for decoding, enrichment, filtering, and JSON output.
+- [netwatch](https://github.com/matthart1983/netwatch) - Network diagnostics TUI that uses an eBPF kprobe on `tcp_v4_connect` (loaded via aya from a sibling `netwatch-sdk` crate) for per-process connection attribution. Connection events flow from a kernel-side ringbuffer into the Connections / Packets / Processes tabs in real time, with `lsof` / `ss` as the fallback when the kprobe can't load (no `CAP_BPF` / kernel < 5.10 / non-Linux). Pairs the eBPF path with libpcap-based deep packet inspection across 13 protocols, TCP retransmit analytics, JA4 fingerprinting, and a Landlock sandbox.
 
 ### Security
 


### PR DESCRIPTION
[netwatch](https://github.com/matthart1983/netwatch) is a Rust network-diagnostics TUI whose process-attribution path is built around an **eBPF kprobe on `tcp_v4_connect`**, loaded via [aya](https://github.com/aya-rs/aya) from a sibling [netwatch-sdk](https://crates.io/crates/netwatch-sdk) crate.

The eBPF program writes per-(pid, comm, 5-tuple) connect events to a kernel-side ringbuffer; the TUI's userspace reader drains them into a per-flow attribution cache that the Connections / Packets / Processes tabs overlay onto `lsof`/`ss`-derived rows. When the kprobe can't load (missing `CAP_BPF` / `CAP_PERFMON`, kernel < 5.10, non-Linux host), the runtime degrades to `lsof`/`ss` polling — eBPF is the preferred source but never a hard requirement.

Other capabilities for context: libpcap-based DPI across 13 protocols (TLS/QUIC/HTTP/DNS/SSH/MQTT/SNMP/...), full RFC 9001 QUIC Initial decryption with cross-packet ClientHello reassembly, TCP retransmit + out-of-order analytics, JA4 fingerprinting, ECH detection, optional Landlock sandbox + capability drop applied after the kprobe attaches.

MIT, Rust, Linux (eBPF path) + macOS (PKTAP fallback). Appended to **Projects Related to eBPF -> Observability**.