### PR TITLE
Add bpfcompat to Testing in Virtual Environments

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -278,6 +278,7 @@ If you are new to eBPF, you may want to try the links described as "introduction
 ### Testing in Virtual Environments
 
 - [bcc in a Docker container](https://github.com/zlim/bcc-docker)
+- [bpfcompat](https://github.com/Kernel-Guard/bpfcompat) - Boots real Linux kernels in disposable QEMU/KVM VMs to load- and attach-validate compiled eBPF objects across a multi-distro, multi-architecture kernel matrix, classifying failures (missing BTF, unsupported map/program type, CO-RE relocations); runs as a CI gate and GitHub Action.
 
 ## Projects Related to eBPF
 


### PR DESCRIPTION
Adds [bpfcompat](https://github.com/Kernel-Guard/bpfcompat) under **eBPF Workflow: Tools and Utilities → Testing in Virtual Environments**.

bpfcompat boots real Linux kernels in disposable QEMU/KVM VMs and load/attach-validates a compiled `.bpf.o` inside each, across a multi-distro, multi-arch (5.x–6.x, x86_64 + ARM64) kernel matrix. On failure it classifies the reason (missing BTF, unsupported map/program type, CO-RE relocation) and emits a JSON/Markdown compatibility matrix; it ships as a CI gate and a GitHub Action. Apache-2.0.

- Single entry, alphabetical (after `bcc in a Docker container`), `- [name](url) - Description.` format.
- `npm run ci-lint` passes locally.