### PR TITLE
Add Assay (Security)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -352,6 +352,7 @@ If you are new to eBPF, you may want to try the links described as "introduction
 - [Bombini](https://github.com/bombinisecurity/bombini) - An eBPF-based security agent written entirely in Rust using the [Aya](https://github.com/aya-rs/aya) library and built on LSM (Linux Security Module) BPF hooks.
 - [owLSM](https://github.com/Cybereason-Public/owLSM) - Open source agent that implements a stateful Sigma rules engine focused on monitoring and prevention using eBPF LSM.
 - [Inner Warden](https://github.com/InnerWarden/innerwarden) - A self-defending security agent for Linux and macOS that uses eBPF with 22 kernel hooks (tracepoints, kprobes, LSM, XDP) via the Aya library for real-time threat detection, automated response, and AI-powered triage.
+- [Assay](https://github.com/Rul1an/assay) - A policy-as-code gate for AI agent (MCP) tool calls, written in Rust, that enforces IPv4/TCP connect-egress policy in the kernel through eBPF LSM hooks and records offline-verifiable evidence of what ran.
 
 ### Linux Scheduler
 


### PR DESCRIPTION
Adds Assay to Projects Related to eBPF > Security. It is a Rust policy gate for AI agent (MCP) tool calls whose Linux enforcement path uses eBPF LSM hooks for IPv4/TCP connect-egress blocking, alongside an offline-verifiable evidence layer. Disclosure: I maintain the project. Placed at the end of the section following the existing entries; happy to move or reword if you prefer.