### PR TITLE
Add Hulios to Security projects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -352,6 +352,7 @@ If you are new to eBPF, you may want to try the links described as "introduction
 - [Bombini](https://github.com/bombinisecurity/bombini) - An eBPF-based security agent written entirely in Rust using the [Aya](https://github.com/aya-rs/aya) library and built on LSM (Linux Security Module) BPF hooks.
 - [owLSM](https://github.com/Cybereason-Public/owLSM) - Open source agent that implements a stateful Sigma rules engine focused on monitoring and prevention using eBPF LSM.
 - [Inner Warden](https://github.com/InnerWarden/innerwarden) - A self-defending security agent for Linux and macOS that uses eBPF with 22 kernel hooks (tracepoints, kprobes, LSM, XDP) via the Aya library for real-time threat detection, automated response, and AI-powered triage.
+- [Hulios](https://github.com/ghaziwali/Hulios) — An eBPF-powered, zero-leak transparent Tor gateway for Linux that secures outbound network traffic using Cgroup v2 socket hooks and LSM raw socket blockers.
 
 ### Linux Scheduler
 


### PR DESCRIPTION
Hi ,
I would like to submit **Hulios** to the Security section of the awesome-ebpf list.

    * **Project Link:** https://github.com/ghaziwali/Hulios
    * **Suggested Entry:**
`* [Hulios](https://github.com/ghaziwali/Hulios) — An eBPF-powered, zero-leak transparent Tor gateway for Linux that secures outbound network traffic using Cgroup v2 socket hooks and LSM raw socket blockers.`

    ### What does the project do?
Hulios is a transparent Tor gateway daemon written in Rust. It utilizes eBPF programs for two main tasks:
    1. **Cgroup v2 Socket Hooks:** Attaches to the root cgroup to automatically mark (`fwmark`) and redirect outgoing TCP and DNS traffic into an unprivileged userspace Arti instance without modifying global system routes.
    2. **LSM Raw Socket Blocker:** Uses BPF LSM hooks to reject `AF_PACKET` raw socket instantiation for non-privileged processes, shutting down a common route for cleartext packet leaks.

It follows strict privilege separation (spins up kernel hooks as root, then drops execution down to `nobody` within a strict `seccomp` sandbox).

Thank you for maintaining this list!
